### PR TITLE
Task/tp 2955 better error handling for wrong ontology name or token

### DIFF
--- a/pytimbr_api/__init__.py
+++ b/pytimbr_api/__init__.py
@@ -1,1 +1,1 @@
-from .timbr_http_connector import advancedQueryExecute, simpleQueryExecution, executeQuery
+from .timbr_http_connector import run_query, advancedQueryExecute, simpleQueryExecution, executeQuery

--- a/pytimbr_api/timbr_http_connector.py
+++ b/pytimbr_api/timbr_http_connector.py
@@ -11,6 +11,19 @@
 
 import requests
 
+
+def _parse_response(response):
+    if response.status_code != 200:
+        raise Exception(f'Error: {response.text}')
+
+    response_json = None
+    try:
+        response_json = response.json()
+    except Exception as e:
+        raise Exception(f'Could not parse response from timbr server: {e}')
+    return response_json
+
+
 def run_query(
     url: str,
     ontology: str,
@@ -43,16 +56,8 @@ def run_query(
       data = query,
       verify = verify_ssl,
     )
-    if response.status_code != 200:
-      raise Exception(f'Error: {response.text}')
-    
-    response_json = None
-    try:
-      response_json = response.json()
-    except Exception as e:
-      raise Exception(f'Could not parse response from timbr server: {e}')
+    return _parse_response(response)
 
-    return response_json
 
 # Deprecated - Backward compatibility
 def executeTimbrQuery(url, ontology, token, query, override_datasource, nested, verify, enableIPv6):
@@ -62,7 +67,7 @@ def executeTimbrQuery(url, ontology, token, query, override_datasource, nested, 
   headers = {'Content-Type': 'application/text', 'x-api-key': token, 'nested': nested, 'Connection': 'close'}
   requests.packages.urllib3.util.connection.HAS_IPV6 = enableIPv6
   response = requests.post(f'{url}timbr/openapi/ontology/{ontology}/query{datasource_addition}', headers = headers, data = query, verify = verify)
-  return response.json()
+  return _parse_response(response)
 
 def advancedQueryExecute(hostname, port, ontology, token, query, enabled_ssl=True, verify_ssl=True, nested = 'false', enableIPv6 = False, datasource = None):
   baseUrl = "http"
@@ -89,4 +94,4 @@ def legacyExecuteTimbrQuery(url, ontology, token, query, nested, verify):
   post_data = {'ontology_name': ontology, 'query': query}
   headers = {'Content-Type': 'application/json', 'x-api-key': token, 'nested': nested}
   response = requests.post(url + "timbr/api/query/", headers = headers, json = post_data, verify = verify)
-  return response.json()
+  return _parse_response(response)

--- a/pytimbr_api/timbr_http_connector.py
+++ b/pytimbr_api/timbr_http_connector.py
@@ -11,17 +11,48 @@
 
 import requests
 
-def run_query(url, ontology, token, query, datasource = None, nested = 'false', verify_ssl = True, enable_IPv6 = False):
-  datasource_addition = ''
-  if datasource:
-    datasource_addition = f'?datasource={datasource}'
-  base_url = url
-  if not base_url.endswith('/'):
-    base_url = base_url + '/'
-  headers = {'Content-Type': 'application/text', 'x-api-key': token, 'nested': nested, 'Connection': 'close'}
-  requests.packages.urllib3.util.connection.HAS_IPV6 = enable_IPv6
-  response = requests.post(f'{base_url}timbr/openapi/ontology/{ontology}/query{datasource_addition}', headers = headers, data = query, verify = verify_ssl)
-  return response.json()
+def run_query(
+    url: str,
+    ontology: str,
+    token: str,
+    query: str,
+    datasource: str = None,
+    nested: str = 'false',
+    verify_ssl: bool = True,
+    enable_IPv6: bool = False,
+):
+    datasource_addition = ''
+    if datasource:
+      datasource_addition = f'?datasource={datasource}'
+    
+    base_url = url
+    if not base_url.endswith('/'):
+      base_url = base_url + '/'
+    
+    headers = {
+      'Content-Type': 'application/text',
+      'x-api-key': token,
+      'nested': nested,
+      'Connection': 'close',
+    }
+    
+    requests.packages.urllib3.util.connection.HAS_IPV6 = enable_IPv6
+    response = requests.post(
+      f'{base_url}timbr/openapi/ontology/{ontology}/query{datasource_addition}',
+      headers = headers,
+      data = query,
+      verify = verify_ssl,
+    )
+    if response.status_code != 200:
+      raise Exception(f'Error: {response.text}')
+    
+    response_json = None
+    try:
+      response_json = response.json()
+    except Exception as e:
+      raise Exception(f'Could not parse response from timbr server: {e}')
+
+    return response_json
 
 # Deprecated - Backward compatibility
 def executeTimbrQuery(url, ontology, token, query, override_datasource, nested, verify, enableIPv6):


### PR DESCRIPTION
Add safe coding to handle query errors from timbr server in a better way and propagate the correct error message